### PR TITLE
Added ability to specify FALLBACK

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ var completeTree = mergeTrees([appJs, appCss, publicFiles]);
 module.exports = mergeTrees([completeTree, writeManifest(completeTree)]);
 ```
 
+Options
+-------
+
+You can pass some options as the second argument to `writeManifest`:
+
+```JavaScript
+
+writeManifest(completeTree, {
+	appcacheFile: '/manifest.appcache', // Name of the generated appcache file - default value shown
+	fallback: ['assets/is-online.json assets/offline.json'] // Lines to add to the FALLBACK section of the generated manifest
+});
+```
+
 Ember-cli
 ---------
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var BroccoliManifest = function BroccoliManifest(inTree, options) {
   this.inTree = inTree;
   options = options || {};
   this.appcacheFile = options.appcacheFile || "/manifest.appcache";
+  this.fallback = options.fallback || [];
 };
 
 module.exports = BroccoliManifest;
@@ -19,6 +20,7 @@ BroccoliManifest.prototype.description = "Creates an manifest.appcache file for 
 
 BroccoliManifest.prototype.write = function(readTree, destDir) {
   var appcacheFile = this.appcacheFile;
+  var fallback = this.fallback;
   return readTree(this.inTree).then(function (srcDir) {
     var lines = ["CACHE MANIFEST", "# created " + (new Date()).toISOString(), "", "CACHE:"];
 
@@ -31,6 +33,11 @@ BroccoliManifest.prototype.write = function(readTree, destDir) {
 
       lines.push(file);
     });
+
+    if (fallback.length) {
+      lines.push("", "FALLBACK:");
+      lines.push.apply(lines, fallback);
+    }
 
     lines.push("","NETWORK:","*");
 


### PR DESCRIPTION
The FALLBACK section of the manifest file allows specifying a fallback page when a resource is unavailable:

> An optional section specifying fallback pages if a resource is inaccessible. The first URI is the resource, the second is the fallback used if the network request fails or errors. Both URIs must from the same origin as the manifest file. You can capture specific URLs but also URL prefixes. "images/large/" will capture failures from URLs such as "images/large/whatever/img.jpg".

This pull request allows users to pass an array of lines to be added to the FALLBACK section.