### PR TITLE
External File support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ module.exports = mergeTrees([completeTree, writeManifest(completeTree)]);
 
 In case you do not have `mergeTrees`, just run `npm install --save broccoli-merge-trees`
 
+### External Files
+
+
+```JavaScript
+var mergeTrees = require('broccoli-merge-trees');
+var manifest = require('broccoli-manifest');
+
+...
+  all app.import statements go here
+...
+
+// Write a html5 manifest.appcache file with jquery external
+var completeTree = app.toTree();
+var manifestTree = manifest(completree)
+manifestTree.addExternalFile("https://code.jquery.com/jquery-2.1.1.min.js")
+
+module.exports = mergeTrees([completeTree, manifestTree]);
+```
+
+
+
 Upgrade your index.html
 -----------------------
 

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -8,6 +8,7 @@ var BroccoliManifest = function BroccoliManifest(inTree, options) {
     return new BroccoliManifest(inTree, options);
   }
   this.inTree = inTree;
+  this.externalFiles = [];
   options = options || {};
   this.appcacheFile = options.appcacheFile || "/manifest.appcache";
 };
@@ -17,6 +18,8 @@ BroccoliManifest.prototype.constructor = BroccoliManifest;
 
 BroccoliManifest.prototype.write = function(readTree, destDir) {
   var appcacheFile = this.appcacheFile;
+  var externalFiles = this.externalFiles;
+
   return readTree(this.inTree).then(function (srcDir) {
     var lines = ["CACHE MANIFEST", "# created " + (new Date()).toISOString(), "", "CACHE:"];
 
@@ -30,11 +33,19 @@ BroccoliManifest.prototype.write = function(readTree, destDir) {
       lines.push(file);
     });
 
+    externalFiles.forEach(function (file) {
+      lines.push(file);
+    });
+
     lines.push("","NETWORK:","*");
 
     fs.writeFileSync(path.join(destDir, appcacheFile), lines.join("\n"));
   });
 };
+
+BroccoliManifest.prototype.addExternalFile = function(file) {
+  this.externalFiles.push(file);
+}
 
 function getFilesRecursively(dir, globPatterns) {
   return helpers.multiGlob(globPatterns, { cwd: dir });


### PR DESCRIPTION
I created a way to add external file to manifest

```JavaScript
var mergeTrees = require('broccoli-merge-trees');
var manifest = require('broccoli-manifest');

...
  all app.import statements go here
...

// Write a html5 manifest.appcache file with jquery external
var completeTree = app.toTree();
var manifestTree = manifest(completree)
manifestTree.addExternalFile("https://code.jquery.com/jquery-2.1.1.min.js")

module.exports = mergeTrees([completeTree, manifestTree]);
```