### PR TITLE
use broccoli-funnel to allow excluding files/folders using regex

### DIFF
--- a/lib/ember-addon.js
+++ b/lib/ember-addon.js
@@ -1,7 +1,7 @@
 var path = require('path');
 var fs   = require('fs');
 var mergeTrees = require('broccoli-merge-trees');
-var fileRemover = require('broccoli-file-remover');
+var funnel = require('broccoli-funnel');
 
 var manifest = require('./manifest');
 
@@ -31,8 +31,8 @@ module.exports = {
     var options = this.manifestOptions;  
 
     if (type === 'all' && options.enabled) {
-      manifestTree = fileRemover(tree, {
-        paths: options.excludePaths
+      manifestTree = funnel(tree, {
+        exclude: options.excludePaths
       });
       return mergeTrees([tree, manifest(manifestTree, options)]);
     }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "broccoli-writer": "~0.1.1",
     "broccoli-kitchen-sink-helpers": "~0.2.2",
     "broccoli-merge-trees": "~0.1.4",
-    "broccoli-file-remover": "~0.3.1"
+    "broccoli-funnel": "~0.2.3"
   }
 }


### PR DESCRIPTION
This PR replaces `broccoli-file-remover` with `broccoli-funnel` (https://github.com/broccolijs/broccoli-funnel) which allows excluding files from the tree using regular expressions.

We wanted to exclude all `.map` files, but they are automatically generated and there didn't seem to be a way to use the existing `broccoli-file-remover` with a glob/wildcard pattern.

This allows something like this to correctly remove `index.html` and any `.map` files from the output:

````js
    manifest : {
      enabled: true,
      appcacheFile: "/manifest.appcache",
      excludePaths: ['index.html', new RegExp(/.\.map$/)],
      includePaths: [''],
      network: ['*']
    },
````

Thoughts?