### PR TITLE
Updates for Ember CLI 1.13 compatibility

### DIFF
--- a/lib/ember-addon.js
+++ b/lib/ember-addon.js
@@ -7,17 +7,12 @@ var manifest = require('./manifest');
 
 module.exports = {
   name: 'broccoli-manifest',
-  
-  included: function (app) {
-    this.app = app;
-    this.initializeOptions();
-  },
-  
-  initializeOptions: function () {
-    var options = this.app.options.manifest || {};
+
+  config: function (env, baseConfig) {
+    var options = baseConfig.manifest || {};
 
     var defaultOptions = {
-      enabled: this.app.env === 'production',
+      enabled: env === 'production',
       appcacheFile: "/manifest.appcache",
       excludePaths: ['index.html', 'tests/'],
       includePaths: [],
@@ -32,10 +27,10 @@ module.exports = {
     }
 
     this.manifestOptions = options;
-  },  
+  },
 
   postprocessTree: function (type, tree) {
-    var options = this.manifestOptions;  
+    var options = this.manifestOptions;
 
     if (type === 'all' && options.enabled) {
       manifestTree = funnel(tree, {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A broccoli plugin automating appcache manifest file creation",
   "main": "lib/manifest.js",
   "ember-addon": {
-    "main": "lib/ember-addon.js"
+    "main": "lib/ember-addon.js",
+    "after": "broccoli-asset-rev"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- Loads after `broccoli-asset-rev` so filenames in manifest have fingerprints
- loads config from Ember CLI using the `config` hook