### PR TITLE
Handle external resources and pathPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ENV.manifest = {
   excludePaths: ['index.html', 'someother.html'],
   includePaths: ['/'],
   network: ['api/'],
-  pathPrefix: "http://your.optional.cdn/",
+  prepend: "http://your.optional.cdn/",
   showCreateDate: true
 }
 ````

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ ENV.manifest = {
   excludePaths: ['index.html', 'someother.html'],
   includePaths: ['/'],
   network: ['api/'],
+  pathPrefix: "http://your.optional.cdn/",
   showCreateDate: true
 }
 ````

--- a/lib/ember-addon.js
+++ b/lib/ember-addon.js
@@ -16,7 +16,7 @@ module.exports = {
       appcacheFile: "/manifest.appcache",
       excludePaths: ['index.html', 'tests/'],
       includePaths: [],
-      pathPrefix: baseConfig.baseURL,
+      prepend: baseConfig.baseURL,
       network: ['*'],
       showCreateDate: true
     }

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -14,7 +14,7 @@ var BroccoliManifest = function BroccoliManifest(inTree, options) {
 
   this.network = options.network || ['*'];
   this.fallback = options.fallback || [];
-  this.pathPrefix = options.pathPrefix || '';
+  this.prepend = options.prepend || '';
   this.showCreateDate = options.showCreateDate;
 };
 
@@ -26,7 +26,7 @@ BroccoliManifest.prototype.write = function(readTree, destDir) {
   var includePaths = this.includePaths;
   var network = this.network;
   var fallback = this.fallback;
-  var pathPrefix = this.pathPrefix;
+  var prepend = this.prepend;
   var showCreateDate = this.showCreateDate;
   return readTree(this.inTree).then(function (srcDir) {
     var lines = ["CACHE MANIFEST"];
@@ -46,14 +46,14 @@ BroccoliManifest.prototype.write = function(readTree, destDir) {
       if (!stat.isFile() && !stat.isSymbolicLink())
         return;
 
-      lines.push(typeof pathPrefix === 'function' ? pathPrefix(file) : pathPrefix + file);
+      lines.push(typeof prepend === 'function' ? prepend(file) : prepend + file);
     });
 
     includePaths.forEach(function (file) {
-      if(typeof pathPrefix === 'function'){
-        lines.push(pathPrefix(file));
+      if(typeof prepend === 'function'){
+        lines.push(prepend(file));
       }else{
-        lines.push(file.startsWith("http") ? file : pathPrefix + file);
+        lines.push(file.startsWith("http") ? file : prepend + file);
       }
     });
 

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -50,7 +50,11 @@ BroccoliManifest.prototype.write = function(readTree, destDir) {
     });
 
     includePaths.forEach(function (file) {
-      lines.push(typeof pathPrefix === 'function' ? pathPrefix(file) : pathPrefix + file);
+      if(typeof pathPrefix === 'function'){
+        lines.push(pathPrefix(file));
+      }else{
+        lines.push(file.startsWith("http") ? file : pathPrefix + file);
+      }
     });
 
     lines.push("","NETWORK:");

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -53,7 +53,7 @@ BroccoliManifest.prototype.write = function(readTree, destDir) {
       if(typeof prepend === 'function'){
         lines.push(prepend(file));
       }else{
-        lines.push(file.startsWith("http") ? file : prepend + file);
+        lines.push( /^http[s]*:\/{2}/.test(file) ? file : prepend + file);
       }
     });
 


### PR DESCRIPTION
Fixed an issue where external resources in the `includePaths` array get prepended with `pathPrefix` and ending up in broken uls like `http://my.cdn.com/http://fonts.googleapis.com/...`.

Added `pathPrefix ` to the readme file as well.